### PR TITLE
fix: add missing SUPABASE_SERVICE_ROLE_KEY to scheduler deployment

### DIFF
--- a/apps/scheduler/cloudbuild.yaml
+++ b/apps/scheduler/cloudbuild.yaml
@@ -52,7 +52,7 @@ steps:
         '--cpu=1',
         '--memory=512Mi',
         # Secrets (adjust versions if needed)
-        '--update-secrets=SUPABASE_ANON_KEY=supabase-anon-key:latest,GOOGLE_MAPS_API_KEY=google-maps-api-key:latest,ONESTEP_GPS_API_KEY=onestep-gps-api-key:latest',
+        '--update-secrets=SUPABASE_ANON_KEY=supabase-anon-key:latest,SUPABASE_SERVICE_ROLE_KEY=supabase-service-role-key:latest,GOOGLE_MAPS_API_KEY=google-maps-api-key:latest,ONESTEP_GPS_API_KEY=onestep-gps-api-key:latest',
         # Environment variables - Use substitutions from trigger
         '--set-env-vars=OPTIMIZATION_SERVICE_URL=$_OPTIMIZATION_SERVICE_URL,SUPABASE_URL=$_SUPABASE_URL'
       ]


### PR DESCRIPTION
The scheduler service was failing to start on Cloud Run because it was missing the required SUPABASE_SERVICE_ROLE_KEY environment variable. Added this secret to the Cloud Build deployment configuration to resolve the startup error.

🤖 Generated with [Claude Code](https://claude.ai/code)